### PR TITLE
Support location name as "city, state" format

### DIFF
--- a/lib/volcanic/location/v1/location.rb
+++ b/lib/volcanic/location/v1/location.rb
@@ -75,9 +75,37 @@ class Volcanic::Location::V1::Location
     !(pk.nil? || pk == '')
   end
 
-  # present the locale to target translations value
-  def name(val = locale)
-    @name[:"#{val}"]
+  #6252001 country A PCLI
+  #4361885 State A ADM1 <-------
+  #4373554 county A ADM2
+  #4366945 town P PPL
+  def name(loc: locale, state: false)
+
+    translated_name = @name[:"#{loc}"]
+    
+    return translated_name unless state && @hierarchy
+    
+    return translated_name if %w(ADM1 PCLI PCL).include?(@feature_code)
+
+    state = state_name(loc)
+    if state
+      "#{translated_name}, #{state}" 
+    else
+      translated_name
+    end
+  end
+
+  def state_name(val)
+    return nil unless @hierarchy
+
+    state = hierarchy.detect do |loc|
+      loc.feature_code == 'ADM1'
+    end
+    if state
+      return state.raw_name[:"#{val}"]
+    else
+      return nil
+    end
   end
 
   # returns the raw value of name

--- a/lib/volcanic/location/v1/location.rb
+++ b/lib/volcanic/location/v1/location.rb
@@ -84,21 +84,20 @@ class Volcanic::Location::V1::Location
     !(pk.nil? || pk == '')
   end
 
-  #6252001 country A PCLI
-  #4361885 State A ADM1 <-------
-  #4373554 county A ADM2
-  #4366945 town P PPL
+  # 6252001 country A PCLI
+  # 4361885 State A ADM1 <-------
+  # 4373554 county A ADM2
+  # 4366945 town P PPL
   def name(loc: locale, state: false)
-
     translated_name = @name[:"#{loc}"]
-    
+
     return translated_name unless state && @hierarchy
-    
+
     return translated_name if %w(ADM1 PCLI PCL).include?(@feature_code)
 
     state = state_name(loc)
     if state
-      "#{translated_name}, #{state}" 
+      "#{translated_name}, #{state}"
     else
       translated_name
     end
@@ -110,11 +109,7 @@ class Volcanic::Location::V1::Location
     state = hierarchy.detect do |loc|
       loc.feature_code == 'ADM1'
     end
-    if state
-      return state.raw_name[:"#{val}"]
-    else
-      return nil
-    end
+    state.raw_name[:"#{val}"] if state
   end
 
   # returns the raw value of name

--- a/lib/volcanic/location/v1/location.rb
+++ b/lib/volcanic/location/v1/location.rb
@@ -106,10 +106,12 @@ class Volcanic::Location::V1::Location
   def state_name(val)
     return nil unless @hierarchy
 
-    state = hierarchy.detect do |loc|
-      loc.feature_code == 'ADM1'
+    @state_name ||= begin
+      state = hierarchy.detect do |loc|
+        loc.feature_code == 'ADM1'
+      end
+      state.raw_name[:"#{val}"] if state
     end
-    state.raw_name[:"#{val}"] if state
   end
 
   # returns the raw value of name

--- a/lib/volcanic/location/version.rb
+++ b/lib/volcanic/location/version.rb
@@ -2,6 +2,6 @@
 
 module Volcanic
   module Location
-    VERSION = '1.1.3'
+    VERSION = '1.1.4'
   end
 end

--- a/spec/volcanic/location/v1/location_spec.rb
+++ b/spec/volcanic/location/v1/location_spec.rb
@@ -220,26 +220,28 @@ RSpec.describe Volcanic::Location::V1::Location do
     let(:feature_code) { 'PPL' }
     let(:locale) { :en }
     let(:i18n) { OpenStruct.new(locale: locale) }
-    let(:hierarchy) {[
-      { source_id: 1234, source_type: source_type,
-        name: {
-          'en': 'county-en',
-          'es': 'county-es'
-        },
-        feature_code: 'ADM2'},
-      { source_id: 1235, source_type: source_type,
-        name: {
-          'en': 'state-en',
-          'es': 'state-es'
-        },
-        feature_code: 'ADM1' },
+    let(:hierarchy) do
+      [
+        { source_id: 1234, source_type: source_type,
+          name: {
+            'en': 'county-en',
+            'es': 'county-es'
+          },
+          feature_code: 'ADM2' },
+        { source_id: 1235, source_type: source_type,
+          name: {
+            'en': 'state-en',
+            'es': 'state-es'
+          },
+          feature_code: 'ADM1' },
         { source_id: 1236, source_type: source_type,
           name: {
             'en': 'country-en',
             'es': 'country-es'
           },
-          feature_code: 'PCLI'}
-    ]}
+          feature_code: 'PCLI' }
+      ]
+    end
 
     before do
       stub_const('I18n', i18n)
@@ -257,33 +259,33 @@ RSpec.describe Volcanic::Location::V1::Location do
     describe 'state enabled' do
       context 'no hierarchy' do
         let(:hierarchy) {}
-        it 'returns just name' do 
-          expect(subject.name(state: true)).to eq 'some-name-en' 
+        it 'returns just name' do
+          expect(subject.name(state: true)).to eq 'some-name-en'
         end
       end
       context 'with hierarchy' do
         context 'feature code is a town' do
           let(:feature_code) { 'PPL' }
-          it 'returns name and state' do 
-            expect(subject.name(state: true)).to eq 'some-name-en, state-en' 
+          it 'returns name and state' do
+            expect(subject.name(state: true)).to eq 'some-name-en, state-en'
           end
         end
         context 'feature code is a county' do
           let(:feature_code) { 'ADM2' }
-          it 'returns name and state' do 
-            expect(subject.name(state: true)).to eq 'some-name-en, state-en' 
+          it 'returns name and state' do
+            expect(subject.name(state: true)).to eq 'some-name-en, state-en'
           end
         end
         context 'feature code is a state' do
           let(:feature_code) { 'ADM1' }
-          it 'returns just name' do 
-            expect(subject.name(state: true)).to eq 'some-name-en' 
+          it 'returns just name' do
+            expect(subject.name(state: true)).to eq 'some-name-en'
           end
         end
         context 'feature code is a country' do
           let(:feature_code) { 'PCLI' }
-          it 'returns just name' do 
-            expect(subject.name(state: true)).to eq 'some-name-en' 
+          it 'returns just name' do
+            expect(subject.name(state: true)).to eq 'some-name-en'
           end
         end
         context 'for other locale' do
@@ -291,16 +293,19 @@ RSpec.describe Volcanic::Location::V1::Location do
           it { expect(subject.name(state: true)).to eq 'some-name-es, state-es' }
         end
         context 'no state in hierarchy' do
-          let(:hierarchy) {[
-            { source_id: 1234, source_type: source_type,
-              name: {
-                'en': 'county-en',
-                'es': 'county-es'
-              },
-              feature_code: 'ADM2'}]}
+          let(:hierarchy) do
+            [
+              { source_id: 1234, source_type: source_type,
+                name: {
+                  'en': 'county-en',
+                  'es': 'county-es'
+                },
+                feature_code: 'ADM2' }
+            ]
+          end
 
-          it 'returns just name' do 
-            expect(subject.name(state: true)).to eq 'some-name-en' 
+          it 'returns just name' do
+            expect(subject.name(state: true)).to eq 'some-name-en'
           end
         end
       end


### PR DESCRIPTION
![image](https://github.com/volcanic-uk/location-ruby-gem/assets/90188985/104286c4-c485-42bb-889f-7a1166c959a5)
![image](https://github.com/volcanic-uk/location-ruby-gem/assets/90188985/f45ae3d6-8d53-4af1-a631-70f9ab9e26f2)

Need to first get the location with hierarchy then use loc.name(state: true) to get name as city, state.
Only locations  with feature codes below ADM1 will get states shown